### PR TITLE
Revert max width in media query to original value in shared CSS file

### DIFF
--- a/standings.html
+++ b/standings.html
@@ -43,7 +43,7 @@
         <div class="bx bx-menu" id="menu-icon"></div>
     </header>
 
-    <section class="hero" style="display: block; grid-template-columns: none;">
+    <section class="hero" style="display: inline; grid-template-columns: 1fr; padding: 0 3%; gap: 1rem;">
         <!---This is a test for using the body seperately, can remove the div table body class if neeeded-->
 
         <main class="standingsclass">
@@ -51,10 +51,10 @@
         <!-- first column -->
         <div class="tableclass">
             <div class="innertableclass">
-                <section class="table_header">
+                <section class="table_header" id="standings-section">
                     <h1>Group A</h1>
                 </section>
-                <section class="table_body">
+                <section class="table_body" id="standings-section">
                     <table>
                         <thead>
                             <tr>
@@ -117,10 +117,10 @@
         <!-- second column -->
         <div class="tableclass">
             <div class="innertableclass">
-                <section class="table_header">
+                <section class="table_header" id="standings-section">
                     <h1>Group B</h1>
                 </section>
-                <section class="table_body">
+                <section class="table_body" id="standings-section">
                     <table>
                         <thead>
                             <tr>
@@ -183,10 +183,10 @@
         <!-- second row of first column -->
         <div class="tableclass">
             <div class="innertableclass">
-                <section class="table_header">
+                <section class="table_header" id="standings-section">
                     <h1>Group C</h1>
                 </section>
-                <section class="table_body">
+                <section class="table_body" id="standings-section">
                     <table>
                         <thead>
                             <tr>
@@ -249,10 +249,10 @@
         <!-- second row of second column -->
         <div class="tableclass">
             <div class="innertableclass">
-                <section class="table_header">
+                <section class="table_header" id="standings-section">
                     <h1>Group D</h1>
                 </section>
-                <section class="table_body">
+                <section class="table_body" id="standings-section">
                     <table>
                         <thead>
                             <tr>
@@ -314,10 +314,10 @@
             
         <div class="tableclass">
             <div class="innertableclass">
-                <section class="table_header">
+                <section class="table_header" id="standings-section">
                     <h1>Group E</h1>
                 </section>
-                <section class="table_body">
+                <section class="table_body" id="standings-section">
                     <table>
                         <thead>
                             <tr>
@@ -377,10 +377,10 @@
 
         <div class="tableclass">
             <div class="innertableclass">
-                <section class="table_header">
+                <section class="table_header" id="standings-section">
                     <h1>Group F</h1>
                 </section>
-                <section class="table_body">
+                <section class="table_body" id="standings-section">
                     <table>
                         <thead>
                             <tr>
@@ -441,10 +441,10 @@
 
         <div class="tableclass">
             <div class="innertableclass">
-                <section class="table_header">
+                <section class="table_header" id="standings-section">
                     <h1>Group G</h1>
                 </section>
-                <section class="table_body">
+                <section class="table_body" id="standings-section">
                     <table>
                         <thead>
                             <tr>
@@ -505,10 +505,10 @@
 
         <div class="tableclass">
             <div class="innertableclass">
-                <section class="table_header">
+                <section class="table_header" id="standings-section">
                     <h1>Group H</h1>
                 </section>
-                <section class="table_body">
+                <section class="table_body" id="standings-section">
                     <table>
                         <thead>
                             <tr>

--- a/style.css
+++ b/style.css
@@ -186,7 +186,7 @@ section{
         margin-bottom: 25px;
     }
 }
-@media (max-width: 999995px){
+@media (max-width: 1195px){
     section{
         padding: 0 3%;
         transition: .2s;
@@ -269,6 +269,7 @@ td img {
     /*position: relative;
     top: 40px;*/
     display: inline-table;
+    margin: 1rem;
 }
 
 /*main.table {*/
@@ -283,10 +284,11 @@ td img {
 }
 
 .table_header {
-width: 100%;
-height: 10%;
-background-color: #fff4;
-padding: .8rem 1rem;
+    width: 100%;
+    height: 10%;
+    background-color: #fff4;
+    /*padding: .8rem 1rem;*/
+    padding: 0 3%;
 }
 
 .table_body {
@@ -298,6 +300,7 @@ padding: .8rem 1rem;
     border-radius: .6rem;
 
     overflow: auto;
+    padding: 0 3%;
     
     /*display: inline;*/
 }
@@ -342,6 +345,11 @@ tbody tr:nth-child(even) {
 
 tbody tr:hover {
     background-color: #fff6;
+}
+
+#standings-section {
+    padding: 0 3%;
+    /*transition: .2s;*/
 }
 
 /*!!!!!!!!!!!!!!! THIS NEXT SECTION COVERS ABOUT.HTML!!!!!!!!!!!!!!!!!*/


### PR DESCRIPTION
In #5, one of my changes relied on broadening a particular media query in a shared CSS file as follows:

Original version
`@media (max-width: 1195px){`

Broadened version
`@media (max-width: 999995px){`

Because this setting affects other pages, this can be considered a bug introduced by #5.

So, this PR reverts that statement back to the original version while limiting reapplication, of the desired style, to the Standings page.
