### PR TITLE
Standings page: addressing the same ID value being used by multiple HTML elements

### DIFF
--- a/standings.css
+++ b/standings.css
@@ -1,0 +1,22 @@
+section{
+    padding: 0 3%;
+    transition: .2s;
+}
+.hero-text{
+    padding-top: 115px;
+}
+.hero-img{
+    text-align: center;
+}
+.hero-img img{
+    width: 560px;
+    height: auto;
+}
+.hero{
+    height: 100%;
+    gap: 1rem;
+    grid-template-columns: 1fr;
+}
+.scroll-down{
+    display: none;
+}

--- a/standings.html
+++ b/standings.html
@@ -9,6 +9,7 @@
 
     <!--custom CSS link-->
     <link rel="stylesheet" type="text/css" href="style.css">
+    <link rel="stylesheet" type="text/css" href="standings.css">
 
     <!---boxicons link--->
     <link rel="stylesheet" href="https://unpkg.com/boxicons@latest/css/boxicons.min.css">
@@ -43,7 +44,7 @@
         <div class="bx bx-menu" id="menu-icon"></div>
     </header>
 
-    <section class="hero" style="display: inline; grid-template-columns: 1fr; padding: 0 3%; gap: 1rem;">
+    <section class="hero">
         <!---This is a test for using the body seperately, can remove the div table body class if neeeded-->
 
         <main class="standingsclass">
@@ -51,10 +52,10 @@
         <!-- first column -->
         <div class="tableclass">
             <div class="innertableclass">
-                <section class="table_header" id="standings-section">
+                <section class="table_header">
                     <h1>Group A</h1>
                 </section>
-                <section class="table_body" id="standings-section">
+                <section class="table_body">
                     <table>
                         <thead>
                             <tr>
@@ -117,10 +118,10 @@
         <!-- second column -->
         <div class="tableclass">
             <div class="innertableclass">
-                <section class="table_header" id="standings-section">
+                <section class="table_header">
                     <h1>Group B</h1>
                 </section>
-                <section class="table_body" id="standings-section">
+                <section class="table_body">
                     <table>
                         <thead>
                             <tr>
@@ -183,10 +184,10 @@
         <!-- second row of first column -->
         <div class="tableclass">
             <div class="innertableclass">
-                <section class="table_header" id="standings-section">
+                <section class="table_header">
                     <h1>Group C</h1>
                 </section>
-                <section class="table_body" id="standings-section">
+                <section class="table_body">
                     <table>
                         <thead>
                             <tr>
@@ -249,10 +250,10 @@
         <!-- second row of second column -->
         <div class="tableclass">
             <div class="innertableclass">
-                <section class="table_header" id="standings-section">
+                <section class="table_header">
                     <h1>Group D</h1>
                 </section>
-                <section class="table_body" id="standings-section">
+                <section class="table_body">
                     <table>
                         <thead>
                             <tr>
@@ -314,10 +315,10 @@
             
         <div class="tableclass">
             <div class="innertableclass">
-                <section class="table_header" id="standings-section">
+                <section class="table_header">
                     <h1>Group E</h1>
                 </section>
-                <section class="table_body" id="standings-section">
+                <section class="table_body">
                     <table>
                         <thead>
                             <tr>
@@ -377,10 +378,10 @@
 
         <div class="tableclass">
             <div class="innertableclass">
-                <section class="table_header" id="standings-section">
+                <section class="table_header">
                     <h1>Group F</h1>
                 </section>
-                <section class="table_body" id="standings-section">
+                <section class="table_body">
                     <table>
                         <thead>
                             <tr>
@@ -441,10 +442,10 @@
 
         <div class="tableclass">
             <div class="innertableclass">
-                <section class="table_header" id="standings-section">
+                <section class="table_header">
                     <h1>Group G</h1>
                 </section>
-                <section class="table_body" id="standings-section">
+                <section class="table_body">
                     <table>
                         <thead>
                             <tr>
@@ -505,10 +506,10 @@
 
         <div class="tableclass">
             <div class="innertableclass">
-                <section class="table_header" id="standings-section">
+                <section class="table_header">
                     <h1>Group H</h1>
                 </section>
-                <section class="table_body" id="standings-section">
+                <section class="table_body">
                     <table>
                         <thead>
                             <tr>

--- a/style.css
+++ b/style.css
@@ -347,11 +347,6 @@ tbody tr:hover {
     background-color: #fff6;
 }
 
-#standings-section {
-    padding: 0 3%;
-    /*transition: .2s;*/
-}
-
 /*!!!!!!!!!!!!!!! THIS NEXT SECTION COVERS ABOUT.HTML!!!!!!!!!!!!!!!!!*/
 
 .team {


### PR DESCRIPTION
#7 contained a bug in which the same ID, representing a standings section, was being used by multiple HTML elements.

This PR patches the bug by applying the desired style via a page-specific CSS file instead.