### PR TITLE
Volunteer page: making UX consistent across Desktop and Mobile

### DIFF
--- a/volunteers.html
+++ b/volunteers.html
@@ -49,72 +49,55 @@
         <div class="team">
             <div class="icon">
                 <div class="imgBx" style="--i:1;" data-id="content1">
-                    <a href="https://retroachievements.org/user/VoiceOfAutumn">
-					<img src="https://media.retroachievements.org/UserPic/voiceofautumn.png"></a>
+                    <img src="https://media.retroachievements.org/UserPic/voiceofautumn.png">
                 </div>
                 <div class="imgBx" style="--i:2;" data-id="content2">
-                    <a href="https://retroachievements.org/user/Searo">
-					<img src="https://media.retroachievements.org/UserPic/Searo.png"></a>
+                    <img src="https://media.retroachievements.org/UserPic/Searo.png">
                 </div>
 				<div class="imgBx" style="--i:3;" data-id="content3">
-					<a href="https://retroachievements.org/user/starblades">
-                    <img src="https://media.retroachievements.org/UserPic/starblades.png"></a>
+					<img src="https://media.retroachievements.org/UserPic/starblades.png">
                 </div>
 				<div class="imgBx" style="--i:4;" data-id="content4">
-					<a href="https://retroachievements.org/user/StingX2">
-                    <img src="https://media.retroachievements.org/UserPic/StingX2.png"></a>
+					<img src="https://media.retroachievements.org/UserPic/StingX2.png">
                 </div>
 				<div class="imgBx" style="--i:5;" data-id="content5">
-					<a href="https://retroachievements.org/user/Taysuu">
-                    <img src="https://media.retroachievements.org/UserPic/Taysuu.png"></a>
+					<img src="https://media.retroachievements.org/UserPic/Taysuu.png">
                 </div>
 				<div class="imgBx" style="--i:6;" data-id="content6">
-					<a href="https://retroachievements.org/user/TimeCrush">
-                    <img src="https://media.retroachievements.org/UserPic/TimeCrush.png"></a>
+					<img src="https://media.retroachievements.org/UserPic/TimeCrush.png">
                 </div>
 				<div class="imgBx" style="--i:7;" data-id="content7">
-					<a href="https://retroachievements.org/user/Wimpyfox">
-                    <img src="https://media.retroachievements.org/UserPic/Wimpyfox.png"></a>
+					<img src="https://media.retroachievements.org/UserPic/Wimpyfox.png">
                 </div>
 				<div class="imgBx" style="--i:8;" data-id="content8">
-					<a href="https://retroachievements.org/user/wolfman2000">
-                    <img src="https://media.retroachievements.org/UserPic/wolfman2000.png"></a>
+					<img src="https://media.retroachievements.org/UserPic/wolfman2000.png">
                 </div>
 				<div class="imgBx" style="--i:9;" data-id="content9">
-					<a href="https://retroachievements.org/user/Pampa50">
-                    <img src="https://media.retroachievements.org/UserPic/Pampa50.png"></a>
+				    <img src="https://media.retroachievements.org/UserPic/Pampa50.png">
                 </div>
 				<div class="imgBx" style="--i:10;" data-id="content10">
-					<a href="https://retroachievements.org/user/soltyd">
-                    <img src="https://media.retroachievements.org/UserPic/soltyd.png"></a>
+					<img src="https://media.retroachievements.org/UserPic/soltyd.png">
                 </div>
 				<div class="imgBx" style="--i:11;" data-id="content11">
-					<a href="https://retroachievements.org/user/Bartis1989">
-                    <img src="https://media.retroachievements.org/UserPic/Bartis1989.png"></a>
+					<img src="https://media.retroachievements.org/UserPic/Bartis1989.png">
                 </div>
 				<div class="imgBx" style="--i:12;" data-id="content12">
-					<a href="https://retroachievements.org/user/Bryan1150">
-                    <img src="https://media.retroachievements.org/UserPic/Bryan1150.png"></a>
+					<img src="https://media.retroachievements.org/UserPic/Bryan1150.png">
                 </div>
 				<div class="imgBx" style="--i:13;" data-id="content13">
-					<a href="https://retroachievements.org/user/clymax">
-                    <img src="https://media.retroachievements.org/UserPic/clymax.png"></a>
+					<img src="https://media.retroachievements.org/UserPic/clymax.png">
                 </div>
 				<div class="imgBx" style="--i:14;" data-id="content14">
-					<a href="https://retroachievements.org/user/drisc">
-                    <img src="https://media.retroachievements.org/UserPic/drisc.png"></a>
+					<img src="https://media.retroachievements.org/UserPic/drisc.png">
                 </div>
 				<div class="imgBx" style="--i:15;" data-id="content15">
-					<a href="https://retroachievements.org/user/MonkeyBug">
-                    <img src="https://media.retroachievements.org/UserPic/MonkeyBug.png"></a>
+					<img src="https://media.retroachievements.org/UserPic/MonkeyBug.png">
                 </div>
 				<div class="imgBx" style="--i:16;" data-id="content16">
-					<a href="https://retroachievements.org/user/Nabas6545">
-                    <img src="https://media.retroachievements.org/UserPic/Nabas6545.png"></a>
+					<img src="https://media.retroachievements.org/UserPic/Nabas6545.png">
                 </div>
 				<div class="imgBx" style="--i:17;" data-id="content17">
-					<a href="https://retroachievements.org/user/Tayadaoc">
-                    <img src="https://media.retroachievements.org/UserPic/Tayadaoc.png"></a>
+					<img src="https://media.retroachievements.org/UserPic/Tayadaoc.png">
                 </div>
             </div>
 
@@ -122,170 +105,204 @@
                 <div class="contentBx" id="content1">
                     <div class="card">
                         <div class="imgBx">
-                            <img src="https://media.retroachievements.org/UserPic/voiceofautumn.png">
+                            <a href="https://retroachievements.org/user/VoiceOfAutumn" class="outbound-link">
+                                <img src="https://media.retroachievements.org/UserPic/voiceofautumn.png"></a>
                         </div>
                         <div class="textBx">
-                            <h2>VoiceOfAutumn<br><span>Host & Jack-Of-All-Trades</span></h2>
+                            <a href="https://retroachievements.org/user/VoiceOfAutumn" class="outbound-link">
+                                <h2>VoiceOfAutumn<br><span>Host & Jack-Of-All-Trades</span></h2></a>a>
                         </div>
                     </div>
                 </div>
 				<div class="contentBx" id="content2">
                     <div class="card">
                         <div class="imgBx">
-                            <img src="https://media.retroachievements.org/UserPic/Searo.png">
+                            <a href="https://retroachievements.org/user/Searo" class="outbound-link">
+                                <img src="https://media.retroachievements.org/UserPic/Searo.png"></a>
                         </div>
                         <div class="textBx">
-                            <h2>Searo<br><span>Co-Host & Leaderboard Developer</span></h2>
+                            <a href="https://retroachievements.org/user/Searo" class="outbound-link">
+                                <h2>Searo<br><span>Co-Host & Leaderboard Developer</span></h2></a>
                         </div>
                     </div>
                 </div>
                 <div class="contentBx" id="content3">
                     <div class="card">
                         <div class="imgBx">
-                            <img src="https://media.retroachievements.org/UserPic/starblades.png">
+                            <a href="https://retroachievements.org/user/starblades" class="outbound-link">
+                                <img src="https://media.retroachievements.org/UserPic/starblades.png"></a>
                         </div>
                         <div class="textBx">
-                            <h2>starblades<br><span>Shoutcaster & Media</span></h2>
+                            <a href="https://retroachievements.org/user/starblades" class="outbound-link">
+                            <h2>starblades<br><span>Shoutcaster & Media</span></h2></a>
                         </div>
                     </div>
                 </div>
 				<div class="contentBx" id="content4">
                     <div class="card">
                         <div class="imgBx">
-                            <img src="https://media.retroachievements.org/UserPic/StingX2.png">
+                            <a href="https://retroachievements.org/user/StingX2" class="outbound-link">
+                                <img src="https://media.retroachievements.org/UserPic/StingX2.png"></a>
                         </div>
                         <div class="textBx">
-                            <h2>StingX2<br><span>Shoutcaster</span></h2>
+                            <a href="https://retroachievements.org/user/StingX2" class="outbound-link">
+                            <h2>StingX2<br><span>Shoutcaster</span></h2></a>
                         </div>
                     </div>
                 </div>
 				<div class="contentBx" id="content5">
                     <div class="card">
                         <div class="imgBx">
-                            <img src="https://media.retroachievements.org/UserPic/Taysuu.png">
+                            <a href="https://retroachievements.org/user/Taysuu" class="outbound-link">
+                                <img src="https://media.retroachievements.org/UserPic/Taysuu.png"></a>
                         </div>
                         <div class="textBx">
-                            <h2>Taysuu<br><span>Shoutcaster</span></h2>
+                            <a href="https://retroachievements.org/user/Taysuu" class="outbound-link">
+                            <h2>Taysuu<br><span>Shoutcaster</span></h2></a>
                         </div>
                     </div>
                 </div>
 				<div class="contentBx" id="content6">
                     <div class="card">
                         <div class="imgBx">
-                            <img src="https://media.retroachievements.org/UserPic/TimeCrush.png">
+                            <a href="https://retroachievements.org/user/TimeCrush" class="outbound-link">                
+                            <img src="https://media.retroachievements.org/UserPic/TimeCrush.png"></a>
                         </div>
                         <div class="textBx">
-                            <h2>TimeCrush<br><span>Shoutcaster</span></h2>
+                            <a href="https://retroachievements.org/user/TimeCrush" class="outbound-link">
+                            <h2>TimeCrush<br><span>Shoutcaster</span></h2></a>
                         </div>
                     </div>
                 </div>
 				<div class="contentBx" id="content7">
                     <div class="card">
                         <div class="imgBx">
-                            <img src="https://media.retroachievements.org/UserPic/Wimpyfox.png">
+                            <a href="https://retroachievements.org/user/Wimpyfox" class="outbound-link">                    
+                            <img src="https://media.retroachievements.org/UserPic/Wimpyfox.png"></a>
                         </div>
                         <div class="textBx">
-                            <h2>Wimpyfox<br><span>Shoutcaster</span></h2>
+                            <a href="https://retroachievements.org/user/Wimpyfox" class="outbound-link">                    
+                            <h2>Wimpyfox<br><span>Shoutcaster</span></h2></a>
                         </div>
                     </div>
                 </div>
 				<div class="contentBx" id="content8">
                     <div class="card">
                         <div class="imgBx">
-                            <img src="https://media.retroachievements.org/UserPic/wolfman2000.png">
+                            <a href="https://retroachievements.org/user/wolfman2000" class="outbound-link">                    
+                            <img src="https://media.retroachievements.org/UserPic/wolfman2000.png"></a>
                         </div>
                         <div class="textBx">
-                            <h2>wolfman2000<br><span>Shoutcaster</span></h2>
+                            <a href="https://retroachievements.org/user/wolfman2000" class="outbound-link">                    
+                            <h2>wolfman2000<br><span>Shoutcaster</span></h2></a>
                         </div>
                     </div>
                 </div>
 				<div class="contentBx" id="content9">
                     <div class="card">
                         <div class="imgBx">
-                            <img src="https://media.retroachievements.org/UserPic/Pampa50.png">
+                            	<a href="https://retroachievements.org/user/Pampa50" class="outbound-link">                
+                            <img src="https://media.retroachievements.org/UserPic/Pampa50.png"></a>
                         </div>
                         <div class="textBx">
-                            <h2>Pampa50<br><span>Referee</span></h2>
+                            <a href="https://retroachievements.org/user/Pampa50" class="outbound-link">                
+                            <h2>Pampa50<br><span>Referee</span></h2></a>
                         </div>
                     </div>
                 </div>
 				<div class="contentBx" id="content10">
                     <div class="card">
                         <div class="imgBx">
-                            <img src="https://media.retroachievements.org/UserPic/soltyd.png">
+                            <a href="https://retroachievements.org/user/soltyd" class="outbound-link">                    
+                            <img src="https://media.retroachievements.org/UserPic/soltyd.png"></a>
                         </div>
                         <div class="textBx">
-                            <h2>soltyd<br><span>Referee</span></h2>
+                            <a href="https://retroachievements.org/user/soltyd" class="outbound-link">                    
+                            <h2>soltyd<br><span>Referee</span></h2></a>
                         </div>
                     </div>
                 </div>
 				<div class="contentBx" id="content11">
                     <div class="card">
                         <div class="imgBx">
-                            <img src="https://media.retroachievements.org/UserPic/Bartis1989.png">
+                            <a href="https://retroachievements.org/user/Bartis1989" class="outbound-link">                    
+                            <img src="https://media.retroachievements.org/UserPic/Bartis1989.png"></a>
                         </div>
                         <div class="textBx">
-                            <h2>Bartis1989<br><span>Leaderboard Developer</span></h2>
+                            <a href="https://retroachievements.org/user/Bartis1989" class="outbound-link">                    
+                            <h2>Bartis1989<br><span>Leaderboard Developer</span></h2></a>
                         </div>
                     </div>
                 </div>
 				<div class="contentBx" id="content12">
                     <div class="card">
                         <div class="imgBx">
-                            <img src="https://media.retroachievements.org/UserPic/Bryan1150.png">
+                            <a href="https://retroachievements.org/user/Bryan1150" class="outbound-link">                    
+                            <img src="https://media.retroachievements.org/UserPic/Bryan1150.png"></a>
                         </div>
                         <div class="textBx">
-                            <h2>Bryan1150<br><span>Leaderboard Developer</span></h2>
+                            <a href="https://retroachievements.org/user/Bryan1150" class="outbound-link">                    
+                            <h2>Bryan1150<br><span>Leaderboard Developer</span></h2></a>
                         </div>
                     </div>
                 </div>
 				<div class="contentBx" id="content13">
                     <div class="card">
                         <div class="imgBx">
-                            <img src="https://media.retroachievements.org/UserPic/clymax.png">
+                            <a href="https://retroachievements.org/user/clymax" class="outbound-link">                    
+                            <img src="https://media.retroachievements.org/UserPic/clymax.png"></a>
                         </div>
                         <div class="textBx">
-                            <h2>clymax<br><span>Leaderboard & Web Developer</span></h2>
+                            <a href="https://retroachievements.org/user/clymax" class="outbound-link">                    
+                            <h2>clymax<br><span>Leaderboard & Web Developer</span></h2></a>
                         </div>
                     </div>
                 </div>
 				<div class="contentBx" id="content14">
                     <div class="card">
                         <div class="imgBx">
-                            <img src="https://media.retroachievements.org/UserPic/drisc.png">
+                            <a href="https://retroachievements.org/user/drisc" class="outbound-link">                    
+                            <img src="https://media.retroachievements.org/UserPic/drisc.png"></a>
                         </div>
                         <div class="textBx">
-                            <h2>Drisc<br><span>Web Developer</span></h2>
+                            <a href="https://retroachievements.org/user/drisc" class="outbound-link">                    
+                            <h2>Drisc<br><span>Web Developer</span></h2></a>
                         </div>
                     </div>
                 </div>
 				<div class="contentBx" id="content15">
                     <div class="card">
                         <div class="imgBx">
-                            <img src="https://media.retroachievements.org/UserPic/MonkeyBug.png">
+                            <a href="https://retroachievements.org/user/MonkeyBug" class="outbound-link">                    
+                            <img src="https://media.retroachievements.org/UserPic/MonkeyBug.png"></a>
                         </div>
                         <div class="textBx">
-                            <h2>MonkeyBug<br><span>Web Developer</span></h2>
+                            <a href="https://retroachievements.org/user/MonkeyBug" class="outbound-link">                    
+                            <h2>MonkeyBug<br><span>Web Developer</span></h2></a>
                         </div>
                     </div>
                 </div>
 				<div class="contentBx" id="content16">
                     <div class="card">
                         <div class="imgBx">
-                            <img src="https://media.retroachievements.org/UserPic/Nabas6545.png">
+                            <a href="https://retroachievements.org/user/Nabas6545" class="outbound-link">                    
+                            <img src="https://media.retroachievements.org/UserPic/Nabas6545.png"></a>
                         </div>
                         <div class="textBx">
-                            <h2>Nabas6545<br><span>Media Producer</span></h2>
+                            <a href="https://retroachievements.org/user/Nabas6545" class="outbound-link">                    
+                            <h2>Nabas6545<br><span>Media Producer</span></h2></a>
                         </div>
                     </div>
                 </div>
 				<div class="contentBx" id="content17">
                     <div class="card">
                         <div class="imgBx">
-                            <img src="https://media.retroachievements.org/UserPic/Tayadaoc.png">
+                            <a href="https://retroachievements.org/user/Tayadaoc" class="outbound-link">                    
+                            <img src="https://media.retroachievements.org/UserPic/Tayadaoc.png"></a>
                         </div>
                         <div class="textBx">
-                            <h2>Tayadaoc<br><span>Media Producer</span></h2>
+                            <a href="https://retroachievements.org/user/Tayadaoc" class="outbound-link">                    
+                            <h2>Tayadaoc<br><span>Media Producer</span></h2></a>
                         </div>
                     </div>
                 </div>
@@ -296,7 +313,8 @@
         </div>
  
         <script>
-            let imgBx = document.querySelectorAll('.imgBx')
+            //let imgBx = document.querySelectorAll('.imgBx')
+            let imgBx = document.querySelectorAll('.icon > .imgBx')
             let contentBx = document.querySelectorAll('.contentBx')
 			let randomVolunteer = Math.floor(Math.random() * 17);
 
@@ -304,6 +322,7 @@
 			imgBx[randomVolunteer].className = 'imgBx active';
 			
             for (let i = 0; i < imgBx.length; i++) {
+                // changed from 'mouseover', 'pointerdown'
                 imgBx[i].addEventListener('mouseover', function () {
                     for (let i = 0; i < contentBx.length; i++) {
                         contentBx[i].className = 'contentBx';


### PR DESCRIPTION
This patch was intended to be included in #4, but the file was inadvertently omitted on my part.

**Before this patch**
- Square avatar appears when the user mouses over the round thumbnail.
- Clicking/tapping on the round thumbnail sends the user to the corresponding RA profile in the same browser window.
- The problem is that mobile users don't have a good way to mouse over the round thumbnail without also tapping on it.
- The end result is that mobile users are utterly unable to view the square avatar along with volunteer name and role.

**After this patch**
- Square avatar appears when the user mouses over OR clicks/taps on the round thumbnail.
- Square avatar STAYS until the user mouses over or clicks/taps on a DIFFERENT round thumbnail.
- Clicking the SQUARE AVATAR sends the user to the corresponding RA profile in a new browser window.